### PR TITLE
Improved efficiency of pre-processing step

### DIFF
--- a/src/main/java/db/DatabaseProcessor.java
+++ b/src/main/java/db/DatabaseProcessor.java
@@ -59,7 +59,8 @@ public class DatabaseProcessor {
 	public void updateDblinkcount(int fromId, int toId, int count ) {
 		try {
 			//int currentCount = dbr.getLinkcount(fromId, toId);
-			this.db.executeUpdate("INSERT INTO LINKS VALUES (" + fromId + " , " + toId + " , " + count + ")");
+			this.db.executeUpdate("INSERT INTO LINKS VALUES "
+					+ "(" + fromId + " , " + toId + " , " + count + ")");
 		} catch (SQLException e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/db/DatabaseProcessor.java
+++ b/src/main/java/db/DatabaseProcessor.java
@@ -58,9 +58,8 @@ public class DatabaseProcessor {
 	 */
 	public void updateDblinkcount(int fromId, int toId, int count ) {
 		try {
-			int currentCount = dbr.getLinkcount(fromId, toId);
-			this.db.executeUpdate("UPDATE LINKS SET COUNT = " + (currentCount + count) 
-					+ " WHERE FROMID = " + fromId + " AND TOID = " + toId);
+			//int currentCount = dbr.getLinkcount(fromId, toId);
+			this.db.executeUpdate("INSERT INTO LINKS VALUES (" + fromId + " , " + toId + " , " + count + ")");
 		} catch (SQLException e) {
 			e.printStackTrace();
 		}
@@ -89,6 +88,11 @@ public class DatabaseProcessor {
 			System.out.println(i + "genome(s) analyzed");
 		}
 		System.out.println("Storing link data");
+		try {
+			this.db.executeUpdate("DELETE FROM LINKS");
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}
 		for (int i = 0; i < from.size(); i++) {
 			if ( (i + 1) % (from.size() / 10) == 0) {
 				System.out.println((i * 100 / from.size() + 1) + "% Stored");

--- a/src/main/java/db/DatabaseReader.java
+++ b/src/main/java/db/DatabaseReader.java
@@ -38,12 +38,17 @@ public class DatabaseReader {
 		}
 	}
 	
+	/**
+	 * Returns the number of genomes for each segment of the database
+	 * @return an ArrayList of the number of genomes for each segment of the database
+	 */
+	
 	public ArrayList<Integer> countAllGenomesInSeg() {
 		try {
 			ArrayList<Integer> segments = new ArrayList<Integer>();
 			ResultSet rs = this.db.executeQuery("SELECT SEGMENTID, COUNT(GENOMEID)"
 					+ "FROM GENOMESEGMENTLINK GROUP BY SEGMENTID");
-			while(rs.next()) {
+			while (rs.next()) {
 				segments.add(rs.getInt(2));
 			}
 			return segments;
@@ -70,6 +75,11 @@ public class DatabaseReader {
 			return -1;
 		}
 	}
+	
+	/**
+	 * Returns the amount of segments in the database
+	 * @return the amount of segments in the database
+	 */
 	
 	public int countSegments() {
 		try {
@@ -145,11 +155,17 @@ public class DatabaseReader {
 		return null;
 	}
 	
+	/**
+	 * Returns the first segment id of each genome in the database
+	 * @return the first segment id of each genome in the database
+	 */
+	
 	public ArrayList<Integer> getFirstOfAllGenomes() {
 		ArrayList<Integer> segmentList = new ArrayList<Integer>();
 		try {
 			for (int i = 1; i <= this.countGenomes(); i++) {
-				ResultSet rs = db.executeQuery("SELECT SEGMENTID FROM GENOMESEGMENTLINK WHERE GENOMEID = " + i + " LIMIT 1");
+				ResultSet rs = db.executeQuery("SELECT SEGMENTID FROM GENOMESEGMENTLINK "
+						+ "WHERE GENOMEID = " + i + " LIMIT 1");
 				rs.next();
 				segmentList.add(rs.getInt(1));
 			}
@@ -261,6 +277,13 @@ public class DatabaseReader {
 		return null;
 	}
 	
+	/**
+	 * Returns all links in the dataset. For each segment, an arraylist is created in which
+	 * they can store the segments they link to. All these arraylists are then put into
+	 * an arraylist of arraylists.
+	 * @return Per segment an arraylist of where the respective segments links to.
+	 */
+	
 	public ArrayList<ArrayList<Integer>> getLinks() {
 
 		ArrayList<ArrayList<Integer>> linkList = new ArrayList<ArrayList<Integer>>();
@@ -278,6 +301,13 @@ public class DatabaseReader {
 		}
 		return linkList;
 	}
+	
+	/**
+	 * Returns the number of genomes through a link for each link. For each segment, an arraylist 
+	 * is created in which they can store per segment how many genomes use that link. All these 
+	 * arraylists are then put into an arraylist of arraylists.
+	 * @return for each link how many genomes pass through.
+	 */
 	
 	public ArrayList<ArrayList<Integer>> getLinkWeights() {
 

--- a/src/main/java/db/DatabaseReader.java
+++ b/src/main/java/db/DatabaseReader.java
@@ -38,6 +38,23 @@ public class DatabaseReader {
 		}
 	}
 	
+	public ArrayList<Integer> countAllGenomesInSeg() {
+		try {
+			ArrayList<Integer> segments = new ArrayList<Integer>();
+			ResultSet rs = this.db.executeQuery("SELECT SEGMENTID, COUNT(GENOMEID)"
+					+ "FROM GENOMESEGMENTLINK GROUP BY SEGMENTID");
+			while(rs.next()) {
+				segments.add(rs.getInt(2));
+			}
+			return segments;
+		} catch (SQLException e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+	
+	
+	
 	/**
 	 * Returns the number of genomes in the database, or -1 if an error occurs
 	 * 
@@ -46,6 +63,17 @@ public class DatabaseReader {
 	public int countGenomes() {
 		try {
 			ResultSet rs = this.db.executeQuery("SELECT COUNT(ID) FROM GENOMES");
+			rs.next();
+			return rs.getInt(1);
+		} catch (SQLException e) {
+			e.printStackTrace();
+			return -1;
+		}
+	}
+	
+	public int countSegments() {
+		try {
+			ResultSet rs = this.db.executeQuery("SELECT COUNT(ID) FROM SEGMENTS");
 			rs.next();
 			return rs.getInt(1);
 		} catch (SQLException e) {
@@ -115,6 +143,21 @@ public class DatabaseReader {
 			e.printStackTrace();
 		}
 		return null;
+	}
+	
+	public ArrayList<Integer> getFirstOfAllGenomes() {
+		ArrayList<Integer> segmentList = new ArrayList<Integer>();
+		try {
+			for (int i = 1; i <= this.countGenomes(); i++) {
+				ResultSet rs = db.executeQuery("SELECT SEGMENTID FROM GENOMESEGMENTLINK WHERE GENOMEID = " + i + " LIMIT 1");
+				rs.next();
+				segmentList.add(rs.getInt(1));
+			}
+			return segmentList;
+		} catch (SQLException e) {
+			e.printStackTrace();
+			return null;
+		}
 	}
 	
 	/**
@@ -216,6 +259,43 @@ public class DatabaseReader {
 			e.printStackTrace();
 		}
 		return null;
+	}
+	
+	public ArrayList<ArrayList<Integer>> getLinks() {
+
+		ArrayList<ArrayList<Integer>> linkList = new ArrayList<ArrayList<Integer>>();
+		for (int i = 0; i <= this.countSegments(); i++) {
+			linkList.add(new ArrayList<Integer>());
+		}
+		
+		ArrayList<Integer> fromIDs = this.getAllFromId();
+		ArrayList<Integer> toIDs = this.getAllToId();
+		
+		for (int i = 1; i <= fromIDs.size(); i++) {
+			int fromId = fromIDs.get(i - 1);
+			int toId = toIDs.get(i - 1);
+			linkList.get(fromId - 1).add(toId);
+		}
+		return linkList;
+	}
+	
+	public ArrayList<ArrayList<Integer>> getLinkWeights() {
+
+		ArrayList<ArrayList<Integer>> linkList = new ArrayList<ArrayList<Integer>>();
+		for (int i = 0; i <= this.countSegments(); i++) {
+			linkList.add(new ArrayList<Integer>());
+		}
+		
+		ArrayList<Integer> fromIDs = this.getAllFromId();
+		ArrayList<Integer> weights = this.getAllCounts();
+		
+		
+		for (int i = 1; i <= fromIDs.size(); i++) {
+			int fromId = fromIDs.get(i - 1);
+			int toId = weights.get(i - 1);
+			linkList.get(fromId - 1).add(toId);
+		}
+		return linkList;
 	}
 	
 	/**

--- a/src/main/java/gui/Launcher.java
+++ b/src/main/java/gui/Launcher.java
@@ -23,7 +23,7 @@ public class Launcher extends Application {
 	@Override
 	public void start(Stage stage) throws Exception {
 
-		String filename = "TB10";
+		String filename = "TB328";
     	String gfaPath = System.getProperty("user.dir") + "/Data/" + filename
     			+ "/" + filename + ".gfa";
 		String dbPath = System.getProperty("user.dir") + "/db/" + filename;


### PR DESCRIPTION
Reopened PR 50 after fixing some checkstyle errors.

Executed #47. Due to the big data set being too big to process in a short amount of time, I've made improvements to the pre-processing. With the new improvements, the pre-processing takes a significant less amount of time, making the program able to load in the bigger dataset. This must be added manually to the "Data" folder. The speed improvement for the smaller dataset (TB10) has gone from 5 minutes, to 5 seconds. The bigger data set takes about 6 minutes to pre-process.
