### PR TITLE
Added bigger nodes for longer segments

### DIFF
--- a/src/main/java/gui/GraphController.java
+++ b/src/main/java/gui/GraphController.java
@@ -227,10 +227,13 @@ public class GraphController implements Initializable {
 			int toId = to.get(i);
 			GraphSegment fromsegment = segments.get(fromId);
 			GraphSegment tosegment = segments.get(toId);
-			Line line = new Line(fromsegment.getLayoutX() + fromsegment.getRadius(),
-					fromsegment.getLayoutY() + fromsegment.getRadius(),
-					tosegment.getLayoutX() + tosegment.getRadius(),
-					tosegment.getLayoutY() + tosegment.getRadius());
+			double fromX = fromsegment.getLayoutX() + 2 * Math.log(fromsegment.getContentSize()) 
+				+ fromsegment.getRadius();
+			double toX = tosegment.getLayoutX() + 2 * Math.log(tosegment.getContentSize()) 
+				+ tosegment.getRadius();
+			
+			Line line = new Line(fromX, fromsegment.getLayoutY() + fromsegment.getRadius(),
+					toX, tosegment.getLayoutY() + tosegment.getRadius());
 	        line.setStrokeWidth(1);
 	        res.getChildren().add(line);
 		}

--- a/src/main/java/gui/GraphSegment.java
+++ b/src/main/java/gui/GraphSegment.java
@@ -2,7 +2,7 @@ package gui;
 
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
-import javafx.scene.shape.Circle;
+import javafx.scene.shape.Ellipse;
 import javafx.scene.shape.StrokeType;
 import javafx.scene.text.Text;
 
@@ -32,7 +32,7 @@ public class GraphSegment extends StackPane {
 	/**
 	 * Layout object of segment.
 	 */
-	private Circle image;
+	private Ellipse image;
 	
 	/**
 	 * Creates a new GraphSegment with some standard settings for layout.
@@ -54,7 +54,7 @@ public class GraphSegment extends StackPane {
 	    this.children = new int[childcount];
 	    this.dnacontent = dnacontent;
 		this.setLayout();
-		this.setLayoutCoords(xcoord, ycoord);
+		this.setLayoutCoords(xcoord + 1000, ycoord);
 		this.visualizeDnaContent();
 	}
 	
@@ -62,8 +62,9 @@ public class GraphSegment extends StackPane {
 	 * Sets some basic options for appearance of a segment.
 	 */
 	public void setLayout() {
-	    image = new Circle();
-	    image.setRadius(30);
+	    image = new Ellipse();
+	    image.setRadiusY(30);
+	    image.setRadiusX(30 + 2 * Math.log(dnacontent.length));
 	    image.setFill(Color.DODGERBLUE);
 	    image.setStroke(Color.BLACK);
 	    image.setStrokeType(StrokeType.INSIDE);
@@ -112,6 +113,10 @@ public class GraphSegment extends StackPane {
 	}
 	
 	public double getRadius() {
-		return this.image.getRadius();
+		return this.image.getRadiusY();
+	}
+	
+	public int getContentSize() {
+		return this.dnacontent.length;
 	}
 }


### PR DESCRIPTION
Implemented #61. The graph now has bigger nodes for segments that contain more genes. To not get too big segments, a log scale is used to expand the nodes. The nodes don't use Circles anymore, but they are changed to Ellipses, so they can be expanded in the X-direction.
