### PR TITLE
Coveralls tooling implementation finalized

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,27 +80,25 @@
 					<groupId>org.eluder.coveralls</groupId>
 					<artifactId>coveralls-maven-plugin</artifactId>
     					<version>4.2.0</version>
-					<configuration>
-						<excludes>
-							<exclude>**/*GraphController</exclude>
-							<exclude>**/*GraphSegment</exclude>
-							<exclude>**/*ImportHandler</exclude>
-							<exclude>**/*MainController</exclude>
-							<exclude>**/*Launcher</exclude>
-							<exclude>**/*PhylogenyController</exclude>
-							<exclude>**/*RibbonController</exclude>
-							<exclude>**/*SplashController</exclude>
-							<exclude>**/*NewickEdge</exclude>
-							<exclude>**/*NewickNode</exclude>
-							<exclude>**/*Main</exclude>
-						</excludes>
-					</configuration>
 				</plugin>
 				<plugin>
 				    <groupId>org.codehaus.mojo</groupId>
 				    <artifactId>cobertura-maven-plugin</artifactId>
 				    <version>2.7</version>
 				    <configuration>
+					<instrumentation>
+						<ignores>
+							<ignore>gui.*</ignore>
+							<ignore>gui.phylogeny.*</ignore>
+							<ignore>custommain.>*</ignore>
+						</ignores>
+						<excludes>
+							<exclude>**/gui/*</exclude>
+							<exclude>**/custommain/*</exclude>
+							<exclude>**/gui/phylogeny/*</exclude>
+						</excludes>
+					</instrumentation>
+
 					<format>xml</format>
 					<maxmem>256m</maxmem>
 					<!-- aggregated reports for multi-module projects -->


### PR DESCRIPTION
Cobertura now only provides coverage for relevant classes, not gui classes. Thus, this will only produce relevant coverage reports on our coveralls site. As a result, our coverage is no longer pulled down by untestable classes and we have a clearer overview of what still needs to be tested and what has been sufficiently tested.
