### PR TITLE
Gui/fix graph view

### DIFF
--- a/src/main/java/gui/GraphController.java
+++ b/src/main/java/gui/GraphController.java
@@ -19,8 +19,13 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.ScrollEvent;
 import javafx.scene.layout.GridPane;
+import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
+import javafx.scene.shape.Ellipse;
 import javafx.scene.shape.Line;
+import javafx.scene.shape.StrokeType;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextAlignment;
 
 import db.DatabaseManager;
 import gui.phylogeny.NewickColourMatching;
@@ -319,27 +324,12 @@ public class GraphController implements Initializable {
 	 */
 	private Group getGraphSegments() {
 		Group res = new Group();
+		ArrayList<GraphSegment> k = new ArrayList<GraphSegment>();
 		for (int i = 1; i <= segments.size(); i++) {
-			System.out.println(i);
-			res.getChildren().add(segments.get(i));
+			res.getChildren().add(createEllipse(i));
+			res.getChildren().add(visualizeDnaContent(i));
 		}
 		return res;
-	}
-	
-	/**
-	 * Scales and re-uses the x-coordinates calculated for the ribbon visualization.
-	 * 
-	 * @param xcoords
-	 * 			x-coordinates of ribbons.
-	 * @return xcoords
-	 * 			x-coordinates of graph segments.
-	 */
-	public ArrayList<Integer> scaleRibbonToGraphCoordsX(ArrayList<Integer> xcoords) {
-		for (int i = 0; i < xcoords.size(); i++) {
-			int newc = xcoords.remove(i) * 100;
-			xcoords.add(i, newc);
-		}
-		return xcoords;
 	}
 	
 	public Paint getLineColor(int fromId, int toId) {
@@ -409,5 +399,37 @@ public class GraphController implements Initializable {
 			list.add(i);
 		}
 		return list;
+	}
+	
+	public Ellipse createEllipse(int segmentId) {
+		String content = segmentdna.get(segmentId - 1);
+		double xcoord = graphxcoords.get(segmentId - 1);
+		double ycoord = graphycoords.get(segmentId - 1);
+		double xradius = 30 + 2 * Math.log(content.length());
+		Ellipse node = new Ellipse(xcoord, ycoord, xradius, 30);
+	    node.setFill(Color.DODGERBLUE);
+	    node.setStroke(Color.BLACK);
+	    node.setStrokeType(StrokeType.INSIDE);
+		return node;
+	}
+	
+	private Text visualizeDnaContent(Integer segmentId) {
+		String content = segmentdna.get(segmentId - 1);
+		double xcoord = graphxcoords.get(segmentId - 1);
+		double ycoord = graphycoords.get(segmentId - 1);
+		StringBuilder sb = new StringBuilder();
+		for (int j = 0; j < content.length() && j <= 4; j++) {
+			sb.append(content.substring(j, j + 1));
+		}
+		if ( content.length() > 5) {
+			sb.append("...");
+		}
+		Text dnatext = new Text();
+		dnatext.setTextAlignment(TextAlignment.CENTER);
+		dnatext.setText(sb.toString());
+		double width = dnatext.getLayoutBounds().getWidth();
+		dnatext.setLayoutX(xcoord - 0.5 * width);
+		dnatext.setLayoutY(ycoord + 5);
+		return dnatext;
 	}
 }

--- a/src/main/java/gui/GraphController.java
+++ b/src/main/java/gui/GraphController.java
@@ -5,6 +5,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.ResourceBundle;
 import java.util.Set;
 
@@ -324,10 +325,11 @@ public class GraphController implements Initializable {
 	 */
 	private Group getGraphSegments() {
 		Group res = new Group();
-		ArrayList<GraphSegment> k = new ArrayList<GraphSegment>();
-		for (int i = 1; i <= segments.size(); i++) {
-			res.getChildren().add(createEllipse(i));
-			res.getChildren().add(visualizeDnaContent(i));
+		Iterator<Integer> iterator = segmentIds.iterator();
+		while(iterator.hasNext()) {
+			int segmentId = iterator.next();
+			res.getChildren().add(createEllipse(segmentId));
+			res.getChildren().add(visualizeDnaContent(segmentId));
 		}
 		return res;
 	}
@@ -401,6 +403,10 @@ public class GraphController implements Initializable {
 		return list;
 	}
 	
+	/**
+	 * Returns a visualization of a graph segment
+	 */
+	
 	public Ellipse createEllipse(int segmentId) {
 		String content = segmentdna.get(segmentId - 1);
 		double xcoord = graphxcoords.get(segmentId - 1);
@@ -413,7 +419,12 @@ public class GraphController implements Initializable {
 		return node;
 	}
 	
-	private Text visualizeDnaContent(Integer segmentId) {
+	/**
+	 * Returns a Text object displaying the DNA strand.
+	 * DNA strands with more than 5 nucleotides only have the first 5 nucleotides displayed.
+	 */
+	
+	private Text visualizeDnaContent(int segmentId) {
 		String content = segmentdna.get(segmentId - 1);
 		double xcoord = graphxcoords.get(segmentId - 1);
 		double ycoord = graphycoords.get(segmentId - 1);

--- a/src/main/java/gui/GraphSegment.java
+++ b/src/main/java/gui/GraphSegment.java
@@ -46,7 +46,7 @@ public class GraphSegment extends StackPane {
 	 */
 	public GraphSegment(int segmentid, int childcount, char[] dnacontent, int xcoord, int ycoord) {
 		this(segmentid, childcount, dnacontent);
-		this.setLayoutCoords(xcoord + 1000, ycoord);
+		this.setLayoutCoords(xcoord - 30, ycoord - 30);
 	}
 	
 	/**

--- a/src/main/java/gui/MainController.java
+++ b/src/main/java/gui/MainController.java
@@ -91,9 +91,10 @@ public class MainController implements Initializable {
 			        		ArrayList<Integer> genomeIds = Launcher.dbm.getDbReader()
 			        				.findGenomeId(genomeNames);
 			        		ribbonTabController.setGenomeIds(genomeIds);
-			        		ribbonTabController.redraw();
 			        		graphTabController.setGenomeIds(genomeIds);
 			        		graphTabController.redraw();
+			        		ribbonTabController.setGraphGroup(graphTabController.getInnerGroup());
+			        		ribbonTabController.redraw();
 			        		NewickNode.setChanged(false);
 			        	}
 			        }

--- a/src/main/java/gui/MainController.java
+++ b/src/main/java/gui/MainController.java
@@ -92,6 +92,8 @@ public class MainController implements Initializable {
 			        				.findGenomeId(genomeNames);
 			        		ribbonTabController.setGenomeIds(genomeIds);
 			        		ribbonTabController.redraw();
+			        		graphTabController.setGenomeIds(genomeIds);
+			        		graphTabController.redraw();
 			        		NewickNode.setChanged(false);
 			        	}
 			        }

--- a/src/main/java/gui/RibbonController.java
+++ b/src/main/java/gui/RibbonController.java
@@ -285,14 +285,6 @@ public class RibbonController implements Initializable {
 					return NewickColourMatching.getLineageColour(lineages.get(genome));
 				}
 			}
-		} else if (from.size() < to.size()) {
-			for (int i = 0; i < from.size(); i++) {
-				String genome = from.get(i);
-				if (lineages.containsKey(genome) && to.contains(genome) 
-						&& !genome.equals("MT_H37RV_BRD_V5.ref")) {
-					return NewickColourMatching.getLineageColour(lineages.get(genome));
-				}
-			}
 		} else {
 			for (int i = 0; i < from.size(); i++) {
 				String genome = from.get(i);

--- a/src/main/java/gui/RibbonController.java
+++ b/src/main/java/gui/RibbonController.java
@@ -220,6 +220,7 @@ public class RibbonController implements Initializable {
 		);
 		
 		double maxY = dbm.getDbReader().getMaxYCoord();
+		System.out.println("MaxY in the graph controller = " + maxY);
 		innerGroup.setScaleY(720.0 / maxY);
 		innerGroup.setScaleX(MIN_SCALE);
 		


### PR DESCRIPTION
Fix #119. The graph now correctly shows when zooming all the way in.

To increase the efficiency of the program, the GraphSegment class is not used anymore. For some reason, java was taking way too much time adding these to a group after selecting different genomes. This wasn't noticed before, since the first runthrough it goes really fast. So instead of using GraphSegments, we immediately put Ellipses into the group. 
